### PR TITLE
Add FastAPI proxy for Stability AI image-to-3D

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,25 @@
+"""Authentication helpers using JWT tokens."""
+import os
+from typing import Any, Dict
+
+import jwt
+from fastapi import Depends, HTTPException
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+
+bearer_scheme = HTTPBearer()
+
+
+def verify_jwt(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)) -> Dict[str, Any]:
+    """Validate a JWT passed via the Authorization header.
+
+    The JWT is expected to be signed using the secret in ``JWT_SECRET`` with the
+    HS256 algorithm.  If the token is invalid or missing, an HTTP 401 is raised.
+    """
+    token = credentials.credentials
+    secret = os.getenv("JWT_SECRET")
+    if not secret:
+        raise HTTPException(status_code=500, detail="JWT secret not configured")
+    try:
+        return jwt.decode(token, secret, algorithms=["HS256"])
+    except jwt.PyJWTError as exc:
+        raise HTTPException(status_code=401, detail="Invalid authentication token") from exc

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,51 @@
+"""FastAPI application that proxies Stability AI's image-to-3D generation."""
+from __future__ import annotations
+
+import os
+import uuid
+
+import httpx
+from fastapi import Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+
+from .auth import verify_jwt
+from .storage import get_model_path, save_model
+
+app = FastAPI(title="Image to 3D API")
+
+STABILITY_API_URL = "https://api.stability.ai/vX/3d/generate"
+
+
+@app.post("/generate")
+async def generate_3d_model(
+    image: UploadFile = File(...),
+    _claims: dict = Depends(verify_jwt),
+) -> dict:
+    """Accept an image and return a URL to the generated 3D model."""
+    if image.content_type not in {"image/png", "image/jpeg"}:
+        raise HTTPException(status_code=400, detail="Unsupported image type")
+
+    api_key = os.getenv("STABILITY_API_KEY")
+    if not api_key:
+        raise HTTPException(status_code=500, detail="Stability API key not configured")
+
+    job_id = str(uuid.uuid4())
+    async with httpx.AsyncClient(timeout=60) as client:
+        response = await client.post(
+            STABILITY_API_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            files={"image": (image.filename, await image.read(), image.content_type)},
+        )
+    response.raise_for_status()
+
+    save_model(job_id, response.content)
+    return {"job_id": job_id, "model_url": f"/asset/{job_id}"}
+
+
+@app.get("/asset/{job_id}")
+async def get_asset(job_id: str, _claims: dict = Depends(verify_jwt)) -> FileResponse:
+    """Return the stored 3D model for ``job_id``."""
+    path = get_model_path(job_id)
+    if not path:
+        raise HTTPException(status_code=404, detail="Model not found")
+    return FileResponse(path)

--- a/app/storage.py
+++ b/app/storage.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+# Directory where generated models are stored.
+MODEL_DIR = Path(os.getenv("MODEL_DIR", "models"))
+MODEL_DIR.mkdir(parents=True, exist_ok=True)
+
+def save_model(job_id: str, data: bytes) -> Path:
+    """Persist the model bytes to disk.
+
+    In production this would upload to a secure object store (e.g., S3) and
+    return a presigned URL. For the purposes of this repository we store the
+    file locally under ``models/``.
+    """
+    path = MODEL_DIR / f"{job_id}.glb"
+    path.write_bytes(data)
+    return path
+
+def get_model_path(job_id: str) -> Optional[Path]:
+    """Return the path to the stored model if it exists."""
+    path = MODEL_DIR / f"{job_id}.glb"
+    return path if path.exists() else None

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+httpx
+python-multipart
+PyJWT


### PR DESCRIPTION
## Summary
- add FastAPI service exposing /generate and /asset endpoints
- verify JWT tokens and forward requests to Stability AI
- store generated models locally for retrieval

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895091a0ee08323a3c0ad2b0bde2da7