### PR TITLE
Add Render deployment configuration

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,17 @@
+services:
+  - type: web
+    name: web
+    runtime: python
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn app.main:app --host 0.0.0.0 --port $PORT
+    envVars:
+      - key: STABILITY_API_KEY
+        sync: false
+      - key: JWT_SECRET
+        sync: false
+      - key: MODEL_DIR
+        value: /var/models
+    disk:
+      name: models
+      mountPath: /var/models
+      sizeGB: 1


### PR DESCRIPTION
## Summary
- add render.yaml to describe a Python web service for Render
- configure build and start commands for uvicorn app server
- declare environment variables and persistent disk storage for models

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68950d52edc8832383ebdc035ebe6a4d